### PR TITLE
Update registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,11 +178,11 @@ We then need to define the behavior of the functions `my_func` and `bar`.
 from levy.config import Config
 from levy.renderer import render_reg
 
-@render_reg.add('my_func')
+@render_reg.add()  # By default, it registers the function name
 def my_func(num: int):
     return num + 1
 
-@render_reg.add('bar')  # Name can be arbitrary
+@render_reg.add('bar')  # Name can be overwritten if required
 def upper(s: str):
     return s.upper()
 
@@ -195,6 +195,20 @@ Note how we registered `my_func` with the same name it appeared in the YAML. How
 the name is completely arbitrary, and we can pass the function `upper` with the name `bar`.
 
 With this approach one can add even further dynamism to the YAML config files.
+
+To peek into the registry state, we can run:
+
+```python
+render_reg.registry
+```
+
+Which in the example will show us
+
+```
+{'env': <function __main__.get_env(conf_str: str, default: Optional[str] = None) -> str>,
+ 'my_func': <function __main__.my_func(num: int)>,
+ 'bar': <function __main__.upper(s: str)>}
+```
 
 ## Contributing
 

--- a/levy/config.py
+++ b/levy/config.py
@@ -10,10 +10,6 @@ from levy.renderer import render_str
 from levy.exceptions import ListParseException
 
 
-class _NULL:  # pylint: disable=too-few-public-methods
-    """Used to have an internal alternative to None"""
-
-
 class Config:
     """
     This class parses the pipelines config files
@@ -122,14 +118,14 @@ class Config:
         else:
             self.__setattr__(key, values)
 
-    def __call__(self, key: str, default: Optional[Any] = _NULL):
+    def __call__(self, key: str, default: Optional[Any] = ...):
         """
         Used for info retrieval
         :param key: attribute to get
         :param default: optional default to get if key not in __dict__
         :return:
         """
-        if default is _NULL:
+        if default is ...:
             return self.__getattribute__(key)
 
         return self.__getattribute__(key) if key in self.__dict__ else default

--- a/levy/renderer.py
+++ b/levy/renderer.py
@@ -16,9 +16,10 @@ def register():
     """
     registry = dict()
 
-    def add(name: str):
+    def add(name: str = None):
         def inner(fn):
-            registry[name] = fn
+            _name = fn.__name__ if not name else name
+            registry[_name] = fn
             return fn
 
         return inner

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -85,7 +85,7 @@ class TestConfig:
         Check renderer registry is applied when reading YAML
         """
 
-        @render_reg.add("my_func")
+        @render_reg.add()
         def my_func(num: int):
             return num + 1
 


### PR DESCRIPTION
- Update registry to use fn.__name__ by default
- Use Ellipsis instead of custom _NULL class for default call